### PR TITLE
Add code coverage facilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ gnatinspect.db
 *.ali
 *.cswi
 *-loc.xml
+cvg

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,22 @@ adayaml:
 test:
 	gprbuild -p -s -P yaml-tests.gpr
 
+test-coverage:
+	gprbuild -p -s -P yaml-tests.gpr --subdirs=cvg \
+		-cargs -g -fdump-scos -fpreserve-control-flow
+test-coverage-run: test-coverage
+	rm -rf cvg
+	mkdir cvg
+	gnatcov run -o cvg/yaml-lexer-harness.trace \
+		test/bin/cvg/yaml-lexer-harness
+	gnatcov run -o cvg/yaml-parser-harness.trace \
+		test/bin/cvg/yaml-parser-harness
+	gnatcov coverage -P yaml-tests.gpr --projects yaml --subdirs=cvg \
+		--annotate dhtml --level stmt+decision \
+		--output-dir=cvg cvg/*.trace
+	@echo "==="
+	@echo "HTML coverage report generated at $$PWD/cvg/index.html"
+
 utils:
 	gprbuild -p -s -P yaml-utils.gpr
 

--- a/Readme.md
+++ b/Readme.md
@@ -64,12 +64,20 @@ This builds the unit tests. The executables will be located in the
 `test/bin` directory (be sure that the root folder is the working directory when
 executing).
 
+If you have [GNAT GPL](http://libre.adacore.com/download/configurations) and
+[GNATcoverage](https://github.com/AdaCore/gnatcoverage), you can also compute
+code coverage from the testsuite:
+
+    make test-coverage-run
+
+The following builds a small utility that reads a YAML files and outputs a
+stream of events to the command line:
+
     make utils
 
-This builds a small utility that reads a YAML files and outputs a stream of
-events to the command line. It is located in `util/bin` afterwards. The tool
-reads either the file specified as first command line parameter, or, in absense
-of that parameter, from stdin.
+It is located in `util/bin` afterwards. The tool reads either the file
+specified as first command line parameter, or, in absense of that parameter,
+from stdin.
 
 To edit the code, you can use GNAT Programming Studio to open the `*.gpr` files.
 

--- a/Readme.md
+++ b/Readme.md
@@ -52,15 +52,6 @@ Status of YAML 1.3 features, taken from [this list][1]:
 
 ## Hacking
 
-After cloning, to fetch the yaml test suite, do:
-
-    git submodule init
-    git submodule update
-
-For updating the test suite, always use
-
-    git submodule update --remote
-
 These commands may be useful for toying around:
 
     make adayaml


### PR DESCRIPTION
Hello,

I started to play a bit with this project and thought it could be useful to compute code coverage from the testsuite. This change adds a Makefile target for that, which should work assuming one has GNATcoverage (available on GitHub) and a GNAT GPL release (for the special compiler support that GNATcoverage requires currently). See http://tmp.kawie.fr/adayaml-cvg/ for an example of a coverage report.

I hope you’ll find this useful!